### PR TITLE
Add Kenshoo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,8 @@ var parse = require('component-querystring').parse;
  */
 var QUERYIDS = {
   btid: 'dataxu',
-  urid: 'millennial-media'
+  urid: 'millennial-media',
+  k_clickid: 'kenshoo'
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,4 +20,10 @@ describe('ad-params', function() {
     assert.strictEqual(res.id, 'qwerqwer');
     assert.strictEqual(res.type, 'millennial-media');
   });
+  
+  it('should parse kenshoo ad param', function() {
+    var res = ads('?k_clickid=qwerqwer&special=lkjlkj');
+    assert.strictEqual(res.id, 'qwerqwer');
+    assert.strictEqual(res.type, 'kenshoo');
+  });
 });


### PR DESCRIPTION
New server-side kenshoo integration requires `ctx.referrer.type==='kenshoo' && ctx.referrer.id`. Populating these values automatically via ajs would allow us to fully remove the client side integration 💥  (we can anyway but this make enabling the kenshoo integration 100x easier)
