### PR TITLE
Add new providers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,10 @@ var parse = require('component-querystring').parse;
  */
 var QUERYIDS = {
   btid: 'dataxu',
-  urid: 'millennial-media'
+  urid: 'millennial-media',
+  gclid: 'google',
+  msclkid: 'bing-ads',
+  k_clickid: 'kenshoo'
 };
 
 /**


### PR DESCRIPTION
Adds Google Ads, Bing Ads, and Kenshoo. 

With the advent of ITP 2.0, most players are conceding that for Apple Platforms, Click Through Conversion is the best they're going to be able to do. This diminishes the need for their scripts to be present at all on Apple Platforms (vs. analytics.js capturing the click IDs, sending to the central pipeline, and then making server to server requests from there). 

Advertisers who elect to make these conversion requests via server to server mechanisms across all platforms likely to see lift in conversion rate due to faster sites that may offset the perceived cost of loss of view-through attribution fidelity (which has long since been waning in accuracy anyways). 